### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Android 精选话题讨论
 隶属于 [Android 问题交流讨论坛](https://github.com/android-cn/android-discuss) 的精华话题。  
 
-####1. 话题讨论-集思广益
+#### 1. 话题讨论-集思广益
 大家可以在 [Issues](https://github.com/android-cn/topics/issues) 中对相应话题发表自己的看法，目前包括：  
 - [Android 开发中你遇到过哪些兼容性问题？都是怎么解决的？](https://github.com/android-cn/topics/issues/2)
 - [你在工作中遇到的最复杂的问题或者 Bug 是什么？你是怎么搞定的?](https://github.com/android-cn/topics/issues/3)
 - [Android 第三方 Push 推送方案使用情况调查](https://github.com/android-cn/topics/issues/4)
 
-####2. 其他
+#### 2. 其他
 - 问答请到 [Android 问题交流讨论坛](https://github.com/android-cn/android-discuss)。 
 - 不建议随便新增 Issue，需要新增的话题请先到 [讨论话题收集](https://github.com/android-cn/topics/issues/1) 中提出建议。
 - `Watch`接受最新 Issue 通知，单个 Issue 可以`Subscribe`订阅。  
 
-####大家多 Star、Watch，发表自己的看法，一起让这个开源项目扩大，互帮互益。  
+#### 大家多 Star、Watch，发表自己的看法，一起让这个开源项目扩大，互帮互益。  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
